### PR TITLE
Add a DNS solution to the Mininet emulation

### DIFF
--- a/nets/8r-1c-in-band-isis/etc-hosts
+++ b/nets/8r-1c-in-band-isis/etc-hosts
@@ -1,15 +1,9 @@
-127.0.0.1	localhost
-127.0.1.1	rose-srv6
-
-# The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-
 # Mininet hosts
+
+# Controller
 fcff:2:c::2     controller
+
+# Routers
 fcff:1::1       r1
 fcff:2::1       r2
 fcff:3::1       r3
@@ -18,6 +12,8 @@ fcff:5::1       r5
 fcff:6::1       r6
 fcff:7::1       r7
 fcff:8::1       r8
+
+# Hosts
 fd00:0:11::2    h11
 fd00:0:12::2    h12
 fd00:0:13::2    h13
@@ -30,6 +26,8 @@ fd00:0:53::2    h53
 fd00:0:81::2    h81
 fd00:0:82::2    h82
 fd00:0:83::2    h83
+
+# Data-centers
 fcff:2:1::2     hdc1
 fcff:8:1::2     hdc2
 fcff:5:1::2     hdc3

--- a/nets/8r-1c-in-band-isis/isis8d.py
+++ b/nets/8r-1c-in-band-isis/isis8d.py
@@ -10,7 +10,8 @@ if __name__ == '__main__':
     if os.path.exists('.venv'):
         with open('.venv', 'r') as venv_file:
             # Get virtualenv path from .venv file
-            venv_path = venv_file.read()
+            # and remove trailing newline chars
+            venv_path = venv_file.read().rstrip()
         # Get path of the activation script
         venv_path = os.path.join(venv_path, 'bin/activate_this.py')
         if not os.path.exists(venv_path):

--- a/nets/8r-1c-in-band-isis/isis8d.py
+++ b/nets/8r-1c-in-band-isis/isis8d.py
@@ -46,6 +46,9 @@ PRIVDIR = '/var/priv'
 # to be added to /etc/hosts
 ETC_HOSTS_FILE = './etc-hosts'
 
+# Define whether to add Mininet nodes to /etc/hosts file or not
+ADD_ETC_HOSTS = True
+
 # Define whether to start the node managers on the routers or not
 START_NODE_MANAGERS = False
 
@@ -288,12 +291,14 @@ def simpleTest():
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
     # Add Mininet nodes to /etc/hosts
-    add_nodes_to_etc_hosts()
+    if ADD_ETC_HOSTS:
+        add_nodes_to_etc_hosts()
 
     CLI( net ) 
 
     # Remove Mininet nodes from /etc/hosts
-    remove_nodes_from_etc_hosts(net)
+    if ADD_ETC_HOSTS:
+        remove_nodes_from_etc_hosts(net)
 
     net.stop() 
     stopAll()
@@ -309,6 +314,11 @@ def parse_arguments():
         '--start-node-managers', dest='start_node_managers',
         action='store_true', default=False,
         help='Define whether to start node manager on routers or not'
+    )
+    parser.add_argument(
+        '--no-etc-hosts', dest='add_etc_hosts',
+        action='store_false', default=True,
+        help='Define whether to add Mininet nodes to /etc/hosts file or not'
     )
     # Parse input parameters
     args = parser.parse_args()
@@ -338,6 +348,8 @@ if __name__ == '__main__':
                   'NODE_MANAGER_GRPC_PORT variable')
             print('NODE_MANAGER_GRPC_PORT variable not set in .env file\n')
             exit(-2)
+    # Define whether to add Mininet nodes to /etc/hosts file or not
+    ADD_ETC_HOSTS = args.add_etc_hosts
     # Tell mininet to print useful information
     setLogLevel('info')
     simpleTest()

--- a/nets/8r-1c-in-band-isis/isis8d.py
+++ b/nets/8r-1c-in-band-isis/isis8d.py
@@ -237,7 +237,8 @@ def add_nodes_to_etc_hosts():
     # Import host-ip mapping defined in etc-hosts file
     count = etc_hosts.import_file(ETC_HOSTS_FILE)
     # Print results
-    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+    count = count['add_result']['ipv6_count'] + count['add_result']['ipv4_count']
+    print('*** Added %s entries to /etc/hosts\n' % count)
 
 
 def remove_nodes_from_etc_hosts(net):

--- a/nets/8r-1c-in-band-isis/isis8d.py
+++ b/nets/8r-1c-in-band-isis/isis8d.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import os
+import python_hosts
 import shutil
 from mininet.topo import Topo
 from mininet.node import Host
@@ -15,6 +16,10 @@ BASEDIR = os.getcwd()+"/nodeconf/"
 OUTPUT_PID_TABLE_FILE = "/tmp/pid_table_file.txt"
 
 PRIVDIR = '/var/priv'
+
+# Path of the file containing the entries (ip-hostname)
+# to be added to /etc/hosts
+ETC_HOSTS_FILE = './etc-hosts'
 
 class BaseNode(Host):
 
@@ -178,6 +183,27 @@ def create_topo(my_net):
     add_link(my_net, controller,r2)
 
 
+def add_nodes_to_etc_hosts():
+    # Get /etc/hosts
+    etc_hosts = python_hosts.hosts.Hosts()
+    # Import host-ip mapping defined in etc-hosts file
+    count = etc_hosts.import_file(ETC_HOSTS_FILE)
+    # Print results
+    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+
+
+def remove_nodes_from_etc_hosts(net):
+    print('*** Removing entries from /etc/hosts\n')
+    # Get /etc/hosts
+    etc_hosts = python_hosts.hosts.Hosts()
+    for host in net.hosts:
+        # Remove all the nodes from /etc/hosts
+        etc_hosts.remove_all_matching(name=str(host))
+    # Write changes to /etc/hosts
+    etc_hosts.write()
+
+
+
 def stopAll():
     # Clean Mininet emulation environment
     os.system('sudo mn -c')
@@ -211,7 +237,14 @@ def simpleTest():
         for host in net.hosts:
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
+    # Add Mininet nodes to /etc/hosts
+    add_nodes_to_etc_hosts()
+
     CLI( net ) 
+
+    # Remove Mininet nodes from /etc/hosts
+    remove_nodes_from_etc_hosts(net)
+
     net.stop() 
     stopAll()
 

--- a/nets/8r-1c-out-band-isis/etc-hosts
+++ b/nets/8r-1c-out-band-isis/etc-hosts
@@ -1,14 +1,6 @@
-127.0.0.1	localhost
-127.0.1.1	rose-srv6
-
-# The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-
 # Mininet hosts
+
+# Routers
 fcff:1::1       r1
 fcff:2::1       r2
 fcff:3::1       r3
@@ -17,6 +9,8 @@ fcff:5::1       r5
 fcff:6::1       r6
 fcff:7::1       r7
 fcff:8::1       r8
+
+# Hosts
 fd00:0:11::2    h11
 fd00:0:12::2    h12
 fd00:0:13::2    h13
@@ -29,10 +23,13 @@ fd00:0:53::2    h53
 fd00:0:81::2    h81
 fd00:0:82::2    h82
 fd00:0:83::2    h83
+
+# Data-centers
 fcff:2:1::2     hdc1
 fcff:8:1::2     hdc2
 fcff:5:1::2     hdc3
 
+# Management network
 fcfd:0:0:fd::1	controller.m
 fcfd:0:0:1::1	r1.m
 fcfd:0:0:2::1	r2.m

--- a/nets/8r-1c-out-band-isis/isis8d.py
+++ b/nets/8r-1c-out-band-isis/isis8d.py
@@ -287,7 +287,8 @@ def add_nodes_to_etc_hosts():
     # Import host-ip mapping defined in etc-hosts file
     count = etc_hosts.import_file(ETC_HOSTS_FILE)
     # Print results
-    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+    count = count['add_result']['ipv6_count'] + count['add_result']['ipv4_count']
+    print('*** Added %s entries to /etc/hosts\n' % count)
 
 
 def remove_nodes_from_etc_hosts(net):

--- a/nets/8r-1c-out-band-isis/isis8d.py
+++ b/nets/8r-1c-out-band-isis/isis8d.py
@@ -46,6 +46,9 @@ PRIVDIR = '/var/priv'
 # to be added to /etc/hosts
 ETC_HOSTS_FILE = './etc-hosts'
 
+# Define whether to add Mininet nodes to /etc/hosts file or not
+ADD_ETC_HOSTS = True
+
 # Define whether to start the node managers on the routers or not
 START_NODE_MANAGERS = False
 
@@ -341,12 +344,14 @@ def simpleTest():
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
     # Add Mininet nodes to /etc/hosts
-    add_nodes_to_etc_hosts()
+    if ADD_ETC_HOSTS:
+        add_nodes_to_etc_hosts()
 
     CLI( net ) 
 
     # Remove Mininet nodes from /etc/hosts
-    remove_nodes_from_etc_hosts(net)
+    if ADD_ETC_HOSTS:
+        remove_nodes_from_etc_hosts(net)
 
     net.stop() 
     stopAll()
@@ -362,6 +367,11 @@ def parse_arguments():
         '--start-node-managers', dest='start_node_managers',
         action='store_true', default=False,
         help='Define whether to start node manager on routers or not'
+    )
+    parser.add_argument(
+        '--no-etc-hosts', dest='add_etc_hosts',
+        action='store_false', default=True,
+        help='Define whether to add Mininet nodes to /etc/hosts file or not'
     )
     # Parse input parameters
     args = parser.parse_args()
@@ -391,6 +401,8 @@ if __name__ == '__main__':
                   'NODE_MANAGER_GRPC_PORT variable')
             print('NODE_MANAGER_GRPC_PORT variable not set in .env file\n')
             exit(-2)
+    # Define whether to add Mininet nodes to /etc/hosts file or not
+    ADD_ETC_HOSTS = args.add_etc_hosts
     # Tell mininet to print useful information
     setLogLevel('info')
     simpleTest()

--- a/nets/8r-1c-out-band-isis/isis8d.py
+++ b/nets/8r-1c-out-band-isis/isis8d.py
@@ -249,6 +249,11 @@ def remove_nodes_from_etc_hosts(net):
     for host in net.hosts:
         # Remove all the nodes from /etc/hosts
         etc_hosts.remove_all_matching(name=str(host))
+    # Remove entries related to the management network
+    # These entries are in the form *.m (e.g. r1.m, controller.m)
+    # therefore they are not removed during the previous loop
+    for host in net.hosts:
+        etc_hosts.remove_all_matching(name='%s.m' % host)
     # Write changes to /etc/hosts
     etc_hosts.write()
 

--- a/nets/8r-1c-out-band-isis/isis8d.py
+++ b/nets/8r-1c-out-band-isis/isis8d.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import os
+import python_hosts
 import shutil
 from mininet.topo import Topo
 from mininet.node import Host, OVSBridge
@@ -15,6 +16,10 @@ BASEDIR = os.getcwd()+"/nodeconf/"
 OUTPUT_PID_TABLE_FILE = "/tmp/pid_table_file.txt"
 
 PRIVDIR = '/var/priv'
+
+# Path of the file containing the entries (ip-hostname)
+# to be added to /etc/hosts
+ETC_HOSTS_FILE = './etc-hosts'
 
 class BaseNode(Host):
 
@@ -228,6 +233,26 @@ def create_topo(my_net):
     add_link(my_net, r8, sw)
 
 
+def add_nodes_to_etc_hosts():
+    # Get /etc/hosts
+    etc_hosts = python_hosts.hosts.Hosts()
+    # Import host-ip mapping defined in etc-hosts file
+    count = etc_hosts.import_file(ETC_HOSTS_FILE)
+    # Print results
+    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+
+
+def remove_nodes_from_etc_hosts(net):
+    print('*** Removing entries from /etc/hosts\n')
+    # Get /etc/hosts
+    etc_hosts = python_hosts.hosts.Hosts()
+    for host in net.hosts:
+        # Remove all the nodes from /etc/hosts
+        etc_hosts.remove_all_matching(name=str(host))
+    # Write changes to /etc/hosts
+    etc_hosts.write()
+
+
 def stopAll():
     # Clean Mininet emulation environment
     os.system('sudo mn -c')
@@ -261,7 +286,14 @@ def simpleTest():
         for host in net.hosts:
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
+    # Add Mininet nodes to /etc/hosts
+    add_nodes_to_etc_hosts()
+
     CLI( net ) 
+
+    # Remove Mininet nodes from /etc/hosts
+    remove_nodes_from_etc_hosts(net)
+
     net.stop() 
     stopAll()
 

--- a/nets/8r-1c-srv6-pm/isis8d.py
+++ b/nets/8r-1c-srv6-pm/isis8d.py
@@ -287,7 +287,8 @@ def add_nodes_to_etc_hosts():
     # Import host-ip mapping defined in etc-hosts file
     count = etc_hosts.import_file(ETC_HOSTS_FILE)
     # Print results
-    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+    count = count['add_result']['ipv6_count'] + count['add_result']['ipv4_count']
+    print('*** Added %s entries to /etc/hosts\n' % count)
 
 
 def remove_nodes_from_etc_hosts(net):

--- a/nets/8r-1c-srv6-pm/isis8d.py
+++ b/nets/8r-1c-srv6-pm/isis8d.py
@@ -46,6 +46,9 @@ PRIVDIR = '/var/priv'
 # to be added to /etc/hosts
 ETC_HOSTS_FILE = './etc-hosts'
 
+# Define whether to add Mininet nodes to /etc/hosts file or not
+ADD_ETC_HOSTS = True
+
 # Define whether to start the node managers on the routers or not
 START_NODE_MANAGERS = False
 
@@ -341,12 +344,14 @@ def simpleTest():
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
     # Add Mininet nodes to /etc/hosts
-    add_nodes_to_etc_hosts()
+    if ADD_ETC_HOSTS:
+        add_nodes_to_etc_hosts()
 
     CLI( net ) 
 
     # Remove Mininet nodes from /etc/hosts
-    remove_nodes_from_etc_hosts(net)
+    if ADD_ETC_HOSTS:
+        remove_nodes_from_etc_hosts(net)
  
     net.stop() 
     stopAll()
@@ -362,6 +367,11 @@ def parse_arguments():
         '--start-node-managers', dest='start_node_managers',
         action='store_true', default=False,
         help='Define whether to start node manager on routers or not'
+    )
+    parser.add_argument(
+        '--no-etc-hosts', dest='add_etc_hosts',
+        action='store_false', default=True,
+        help='Define whether to add Mininet nodes to /etc/hosts file or not'
     )
     # Parse input parameters
     args = parser.parse_args()
@@ -391,6 +401,8 @@ if __name__ == '__main__':
                   'NODE_MANAGER_GRPC_PORT variable')
             print('NODE_MANAGER_GRPC_PORT variable not set in .env file\n')
             exit(-2)
+    # Define whether to add Mininet nodes to /etc/hosts file or not
+    ADD_ETC_HOSTS = args.add_etc_hosts
     # Tell mininet to print useful information
     setLogLevel('info')
     simpleTest()

--- a/nets/8routers-isis-ipv6/etc-hosts
+++ b/nets/8routers-isis-ipv6/etc-hosts
@@ -1,14 +1,6 @@
-127.0.0.1	localhost
-127.0.1.1	rose-srv6
-
-# The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-
 # Mininet hosts
+
+# Routers
 fcff:1::1       r1
 fcff:2::1       r2
 fcff:3::1       r3
@@ -17,6 +9,8 @@ fcff:5::1       r5
 fcff:6::1       r6
 fcff:7::1       r7
 fcff:8::1       r8
+
+# Hosts
 fd00:0:11::2    h11
 fd00:0:12::2    h12
 fd00:0:13::2    h13
@@ -29,6 +23,8 @@ fd00:0:53::2    h53
 fd00:0:81::2    h81
 fd00:0:82::2    h82
 fd00:0:83::2    h83
+
+# Data-centers
 fcff:2:1::2     hdc1
 fcff:8:1::2     hdc2
 fcff:5:1::2     hdc3

--- a/nets/8routers-isis-ipv6/isis8d.py
+++ b/nets/8routers-isis-ipv6/isis8d.py
@@ -23,7 +23,8 @@ if __name__ == '__main__':
             code = compile(f.read(), venv_path, 'exec')
             # Execute the activation script to activate the venv
             exec(code, {'__file__': venv_path})
-            
+
+from argparse import ArgumentParser    
 import python_hosts
 import shutil
 from mininet.topo import Topo
@@ -43,6 +44,9 @@ PRIVDIR = '/var/priv'
 # Path of the file containing the entries (ip-hostname)
 # to be added to /etc/hosts
 ETC_HOSTS_FILE = './etc-hosts'
+
+# Define whether to add Mininet nodes to /etc/hosts file or not
+ADD_ETC_HOSTS = True
 
 class BaseNode(Host):
 
@@ -257,19 +261,42 @@ def simpleTest():
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
     # Add Mininet nodes to /etc/hosts
-    add_nodes_to_etc_hosts()
+    if ADD_ETC_HOSTS:
+        add_nodes_to_etc_hosts()
 
     CLI( net ) 
 
     # Remove Mininet nodes from /etc/hosts
-    remove_nodes_from_etc_hosts(net)
+    if ADD_ETC_HOSTS:
+        remove_nodes_from_etc_hosts(net)
 
     net.stop() 
     stopAll()
 
 
+def parse_arguments():
+    # Get parser
+    parser = ArgumentParser(
+        description='Emulation of a Mininet topology (8 routers running '
+                    'IS-IS, 1 controller out-of-band'
+    )
+    parser.add_argument(
+        '--no-etc-hosts', dest='add_etc_hosts',
+        action='store_false', default=True,
+        help='Define whether to add Mininet nodes to /etc/hosts file or not'
+    )
+    # Parse input parameters
+    args = parser.parse_args()
+    # Return the arguments
+    return args
+
+
 
 if __name__ == '__main__':
+    # Parse command-line arguments
+    args = parse_arguments()
+    # Define whether to add Mininet nodes to /etc/hosts file or not
+    ADD_ETC_HOSTS = args.add_etc_hosts
     # Tell mininet to print useful information
     setLogLevel('info')
     simpleTest()

--- a/nets/8routers-isis-ipv6/isis8d.py
+++ b/nets/8routers-isis-ipv6/isis8d.py
@@ -208,7 +208,8 @@ def add_nodes_to_etc_hosts():
     # Import host-ip mapping defined in etc-hosts file
     count = etc_hosts.import_file(ETC_HOSTS_FILE)
     # Print results
-    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+    count = count['add_result']['ipv6_count'] + count['add_result']['ipv4_count']
+    print('*** Added %s entries to /etc/hosts\n' % count)
 
 
 def remove_nodes_from_etc_hosts(net):

--- a/nets/8routers/etc-hosts
+++ b/nets/8routers/etc-hosts
@@ -1,14 +1,6 @@
-127.0.0.1	localhost
-127.0.1.1	rose-srv6
-
-# The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-
 # Mininet hosts
+
+# Routers
 fcff:1::1       r1
 fcff:2::1       r2
 fcff:3::1       r3
@@ -17,6 +9,8 @@ fcff:5::1       r5
 fcff:6::1       r6
 fcff:7::1       r7
 fcff:8::1       r8
+
+# Hosts
 fd00:0:11::2    h11
 fd00:0:12::2    h12
 fd00:0:13::2    h13
@@ -29,3 +23,8 @@ fd00:0:53::2    h53
 fd00:0:81::2    h81
 fd00:0:82::2    h82
 fd00:0:83::2    h83
+
+# Data-centers
+fcff:2:1::2     hdc1
+fcff:8:1::2     hdc2
+fcff:5:1::2     hdc3

--- a/nets/8routers/ospf8r.py
+++ b/nets/8routers/ospf8r.py
@@ -198,7 +198,8 @@ def add_nodes_to_etc_hosts():
     # Import host-ip mapping defined in etc-hosts file
     count = etc_hosts.import_file(ETC_HOSTS_FILE)
     # Print results
-    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+    count = count['add_result']['ipv6_count'] + count['add_result']['ipv4_count']
+    print('*** Added %s entries to /etc/hosts\n' % count)
 
 
 def remove_nodes_from_etc_hosts(net):

--- a/nets/8routers/ospf8r.py
+++ b/nets/8routers/ospf8r.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import os
+import python_hosts
 import shutil
 from mininet.topo import Topo
 from mininet.node import Host
@@ -15,6 +16,10 @@ BASEDIR = os.getcwd()+"/nodeconf/"
 OUTPUT_PID_TABLE_FILE = "/tmp/pid_table_file.txt"
 
 PRIVDIR = '/var/priv'
+
+# Path of the file containing the entries (ip-hostname)
+# to be added to /etc/hosts
+ETC_HOSTS_FILE = './etc-hosts'
 
 class BaseNode(Host):
 
@@ -163,6 +168,27 @@ def create_topo(my_net):
     add_link(h82,r8)
     add_link(h83,r8)
 
+
+def add_nodes_to_etc_hosts():
+    # Get /etc/hosts
+    etc_hosts = python_hosts.hosts.Hosts()
+    # Import host-ip mapping defined in etc-hosts file
+    count = etc_hosts.import_file(ETC_HOSTS_FILE)
+    # Print results
+    print('*** Added %s entries to /etc/hosts\n' % count['write_result']['total_written'])
+
+
+def remove_nodes_from_etc_hosts(net):
+    print('*** Removing entries from /etc/hosts\n')
+    # Get /etc/hosts
+    etc_hosts = python_hosts.hosts.Hosts()
+    for host in net.hosts:
+        # Remove all the nodes from /etc/hosts
+        etc_hosts.remove_all_matching(name=str(host))
+    # Write changes to /etc/hosts
+    etc_hosts.write()
+
+
 def stopAll():
     # Clean Mininet emulation environment
     os.system('sudo mn -c')
@@ -196,7 +222,14 @@ def simpleTest():
         for host in net.hosts:
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
+    # Add Mininet nodes to /etc/hosts
+    add_nodes_to_etc_hosts()
+
     CLI( net ) 
+
+    # Remove Mininet nodes from /etc/hosts
+    remove_nodes_from_etc_hosts(net)
+
     net.stop() 
     stopAll()
 

--- a/nets/8routers/ospf8r.py
+++ b/nets/8routers/ospf8r.py
@@ -24,6 +24,7 @@ if __name__ == '__main__':
             # Execute the activation script to activate the venv
             exec(code, {'__file__': venv_path})
 
+from argparse import ArgumentParser
 import python_hosts
 import shutil
 from mininet.topo import Topo
@@ -43,6 +44,9 @@ PRIVDIR = '/var/priv'
 # Path of the file containing the entries (ip-hostname)
 # to be added to /etc/hosts
 ETC_HOSTS_FILE = './etc-hosts'
+
+# Define whether to add Mininet nodes to /etc/hosts file or not
+ADD_ETC_HOSTS = True
 
 class BaseNode(Host):
 
@@ -247,19 +251,42 @@ def simpleTest():
             file.write("%s %d\n" % (host, extractHostPid( repr(host) )) )
 
     # Add Mininet nodes to /etc/hosts
-    add_nodes_to_etc_hosts()
+    if ADD_ETC_HOSTS:
+        add_nodes_to_etc_hosts()
 
     CLI( net ) 
 
     # Remove Mininet nodes from /etc/hosts
-    remove_nodes_from_etc_hosts(net)
+    if ADD_ETC_HOSTS:
+        remove_nodes_from_etc_hosts(net)
 
     net.stop() 
     stopAll()
 
 
+def parse_arguments():
+    # Get parser
+    parser = ArgumentParser(
+        description='Emulation of a Mininet topology (8 routers running '
+                    'IS-IS, 1 controller out-of-band'
+    )
+    parser.add_argument(
+        '--no-etc-hosts', dest='add_etc_hosts',
+        action='store_false', default=True,
+        help='Define whether to add Mininet nodes to /etc/hosts file or not'
+    )
+    # Parse input parameters
+    args = parser.parse_args()
+    # Return the arguments
+    return args
+
+
 
 if __name__ == '__main__':
+    # Parse command-line arguments
+    args = parse_arguments()
+    # Define whether to add Mininet nodes to /etc/hosts file or not
+    ADD_ETC_HOSTS = args.add_etc_hosts
     # Tell mininet to print useful information
     setLogLevel('info')
     simpleTest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 python-dotenv==0.13.0
+python-hosts==1.0.0
+win-inet-pton==1.1.0


### PR DESCRIPTION
This Pull request adds a DNS solution to the following topologies
- 8routers
- 8routers-isis-ipv6
- 8r-1c-out-band-isis
- 8r-1c-in-band-isis
- 8r-1c-srv6-pm

For each topology, the mapping ip-hostname is defined in a etc-hosts file, placed under the folder of the topology.

When Mininet emualation is started, the functions provided by the python library python-hosts are used to read the entries contained in etc-hosts and to add these entries to the /etc/hosts file.
Moreover, when the Mininet emulation is stopped, these entries are removed from /etc/hosts file to leave the system in a clean state.

The command-line argument --no-etc-hosts allows to override this behavior. When --no-etc-hosts is set, the Mininet entries are not added to /etc/hosts.

This enables the user to ping the Mininet hosts by using their hostnames instead of their IP addresses.

For example,
`mininet> r1 ping r8`


This pull request closes #6 