### PR TITLE
Fix topologies paths in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 *.pid
 *.swp
 
-nets/3routers/starter.sh
-nets/8routers/starter.sh
+nets-unmantained/3routers/starter.sh
+nets-unmantained/8routers/starter.sh
 nets/8routers-isis-ipv6/starter.sh
 nets/8r-1c-in-band-isis/starter.sh
-nets/8r-1c-out-band-isis/starter.sh
-nets/8r-1c-srv6-pm/starter.sh
+nets-unmantained/8r-1c-out-band-isis/starter.sh
+nets-in-progress/8r-1c-srv6-pm/starter.sh


### PR DESCRIPTION
We have done some changes in the structure of the repo rose-srv6-tutorial. Some topologies have been moved to other folders. This PR will fix the paths for these topologies.